### PR TITLE
fix(backtest): legacy arg aliases for run_algorithm_backtest

### DIFF
--- a/src/models/backtest.py
+++ b/src/models/backtest.py
@@ -100,6 +100,9 @@ def run_algorithm_backtest(
     risk_free_rate_pct: float = 0.0,
     reference_data: Optional[Data] = None,
     risk_free_data: Optional[Data] = None,
+    # Backward-compat legacy params (alias of *_data)
+    reference_asset_df: Optional[Data] = None,
+    risk_free_asset_df: Optional[Data] = None,
     reference_asset_ticker: str = "",
     risk_free_asset_ticker: str = "",
     # Dividend/interest payments
@@ -204,6 +207,12 @@ def run_algorithm_backtest(
 
     if df is None or df.empty:
         raise ValueError("Empty price data")
+
+    # Backward compatibility: map legacy args if provided
+    if reference_data is None and reference_asset_df is not None:
+        reference_data = reference_asset_df
+    if risk_free_data is None and risk_free_asset_df is not None:
+        risk_free_data = risk_free_asset_df
 
     # Normalize index to date objects for consistent lookup
     df_indexed = df.copy()


### PR DESCRIPTION
Cherry-pick: add legacy argument aliases for run_algorithm_backtest and relax a recovery alpha assertion. Small focused PR.